### PR TITLE
Delete Flow Definition

### DIFF
--- a/flowDefinitions/DEF_WW_Create_New_Contact_and_Add_as_Entitled_Contact.flowDefinition
+++ b/flowDefinitions/DEF_WW_Create_New_Contact_and_Add_as_Entitled_Contact.flowDefinition
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<FlowDefinition xmlns="http://soap.sforce.com/2006/04/metadata">
-    <activeVersionNumber>5</activeVersionNumber>
-</FlowDefinition>

--- a/package.xml
+++ b/package.xml
@@ -23,10 +23,6 @@
         <name>Flow</name>
     </types>
     <types>
-        <members>DEF_WW_Create_New_Contact_and_Add_as_Entitled_Contact</members>
-        <name>FlowDefinition</name>
-    </types>
-    <types>
         <members>SVMXC__Service_Contract__c-DEF_WW_Service Contract Header Layout</members>
         <members>SVMXC__Service_Contract__c-DEF_WW_Service Contract Line Layout</members>
         <name>Layout</name>


### PR DESCRIPTION
We need to delete the flow version because the version being used in the production is very different from the hotfix and UAT. Hence we will manually activate the flow in the production.